### PR TITLE
Promote dev to main: automatic version tagging (minor on merge, patch on schedule)

### DIFF
--- a/.github/scripts/bump-tag.sh
+++ b/.github/scripts/bump-tag.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -euo pipefail
+
+# Bumps the latest vX.Y.Z tag. By default also publishes a GitHub Release
+# from it, targeting main -- publishing the release is what triggers
+# publish-image.yaml (on: release: types: [published]), which does the
+# actual multi-arch build/push.
+#
+# With --tag-only, only the git tag is created (no Release object, so
+# publish-image.yaml does NOT trigger). Used by the scheduled patch
+# rebuild, which needs to build the image itself with --pull/--no-cache
+# to force apt-get to actually re-run -- publish-image.yaml's cached
+# build would otherwise just replay stale layers and apply no fixes.
+#
+# Usage: bump-tag.sh <minor|patch> [--tag-only]
+# Writes new_tag=<tag> to $GITHUB_OUTPUT when running in Actions.
+
+BUMP_TYPE="${1:?Usage: bump-tag.sh <minor|patch> [--tag-only]}"
+TAG_ONLY="${2:-}"
+
+git fetch --tags --quiet
+latest=$(git tag -l 'v*.*.*' | sort -V | tail -n1)
+if [ -z "$latest" ]; then
+    latest="v0.0.0"
+fi
+
+ver="${latest#v}"
+IFS='.' read -r major minor patch <<< "$ver"
+
+case "$BUMP_TYPE" in
+    minor)
+        minor=$((minor + 1))
+        patch=0
+        ;;
+    patch)
+        patch=$((patch + 1))
+        ;;
+    *)
+        echo "Unknown bump type: $BUMP_TYPE (expected 'minor' or 'patch')" >&2
+        exit 1
+        ;;
+esac
+
+new_tag="v${major}.${minor}.${patch}"
+echo "Bumping $latest -> $new_tag ($BUMP_TYPE)"
+
+git tag "$new_tag"
+git push origin "$new_tag"
+
+if [ "$TAG_ONLY" != "--tag-only" ]; then
+    gh release create "$new_tag" --target main --title "$new_tag" --generate-notes
+fi
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    echo "new_tag=$new_tag" >> "$GITHUB_OUTPUT"
+fi

--- a/.github/workflows/scheduled-rebuild.yaml
+++ b/.github/workflows/scheduled-rebuild.yaml
@@ -1,19 +1,33 @@
-name: Scheduled security rebuild
+name: Scheduled security patch release
 
 on:
   schedule:
     - cron: '0 3 * * 0'   # weekly, Sunday 03:00 UTC
   workflow_dispatch: {}    # allow manual trigger too
 
+permissions:
+  contents: write
+
 jobs:
-  rebuild:
-    name: Rebuild and republish latest
+  patch-release:
+    name: Bump patch tag and rebuild
     runs-on: ubuntu-latest
     steps:
       - name: Check out main
         uses: actions/checkout@v4
         with:
           ref: main
+          fetch-depth: 0
+
+      # --tag-only: creates the git tag but not a GitHub Release, so this
+      # doesn't also trigger publish-image.yaml (that build is cached and
+      # would just replay stale layers -- this job does its own
+      # --pull/--no-cache build below instead, which actually applies fixes)
+      - name: Bump patch version (tag only)
+        id: bump
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: .github/scripts/bump-tag.sh patch --tag-only
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -27,7 +41,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and push (force-pull base image)
+      - name: Build and push (force-pull base image, no cache)
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -35,4 +49,6 @@ jobs:
           pull: true          # force re-checking the registry for a newer ubuntu:24.04, ignore local/cached layers
           no-cache: true      # also skip layer cache for apt-get steps, so package upgrades actually apply
           push: true
-          tags: ludorl82/console:latest
+          tags: |
+            ludorl82/console:latest
+            ludorl82/console:${{ steps.bump.outputs.new_tag }}

--- a/.github/workflows/tag-on-merge.yaml
+++ b/.github/workflows/tag-on-merge.yaml
@@ -1,0 +1,23 @@
+name: Tag on merge to main
+
+on:
+  push:
+    branches: [ "main" ]
+
+permissions:
+  contents: write
+
+jobs:
+  bump-minor:
+    name: Bump minor version and create release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Bump minor version and create release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: .github/scripts/bump-tag.sh minor


### PR DESCRIPTION
## Summary
Replaces #10, which had merge conflicts for the same squash-merge-divergence reason as #8/#9: PR #6's content was already brought into `main` via PR #7's squash merge (since dev had already absorbed PR #6 before PR #7 merged), so `dev`'s own squash commit for #6 conflicted when compared against main again. This branch starts fresh from `main`'s current tip and cherry-picks only the genuinely new commit (PR #9's tag-bump redesign), which applies cleanly.

- `.github/scripts/bump-tag.sh`: computes/creates the next `vX.Y.Z` tag from the latest existing one
- `tag-on-merge.yaml`: bumps minor version + publishes a Release on every merge to main
- `scheduled-rebuild.yaml`: bumps patch version (tag-only) and does its own forced `--pull`/`--no-cache` rebuild weekly

## Test plan
- [ ] Confirm CI passes
- [ ] Confirm no unexpected diff beyond the tag-bump automation

:robot: Generated with Claude Code