### PR TITLE
Use a PAT for release creation so it triggers publish-image.yaml

### DIFF
--- a/.github/workflows/tag-on-merge.yaml
+++ b/.github/workflows/tag-on-merge.yaml
@@ -17,7 +17,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Releases created with the default GITHUB_TOKEN don't trigger other
+      # workflows (anti-recursion safeguard), so publish-image.yaml would
+      # never fire from this. RELEASE_TOKEN is a PAT with contents: write
+      # on this repo -- a release created with it triggers normally.
       - name: Bump minor version and create release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: .github/scripts/bump-tag.sh minor


### PR DESCRIPTION
## Summary
Confirmed after merging #11 and testing the real automation: the v1.2.0 tag/release got created correctly by `tag-on-merge.yaml`, but `publish-image.yaml` never fired from it. Releases created with the default `GITHUB_TOKEN` do not trigger other workflows -- this is a deliberate GitHub anti-recursion safeguard. Switched to a `RELEASE_TOKEN` secret (a fine-grained PAT with `contents: write`), which doesn't have that restriction.

**Requires a repo secret named `RELEASE_TOKEN` to be added** (Settings → Secrets and variables → Actions) before this takes effect -- otherwise the step will fail with an auth error rather than silently doing nothing.

Targeted directly at `main` since `tag-on-merge.yaml` doesn't even run on `dev` (trigger is `push: branches: [main]` only).

## Test plan
- [ ] Add the `RELEASE_TOKEN` secret
- [ ] Merge this PR (bumps to v1.3.0 automatically)
- [ ] Confirm `publish-image.yaml` fires and Docker Hub gets the new tag + updated `latest`

:robot: Generated with Claude Code