### PR TITLE
build: use devcontainer CLI and Features for the base console image

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,14 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "version": "2.5.9",
+      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:cb0c4d3c276f157eed17935747e364178d75fee17f55c4e129966f64633deb3a",
+      "integrity": "sha256:cb0c4d3c276f157eed17935747e364178d75fee17f55c4e129966f64633deb3a"
+    },
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "version": "1.10.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-outside-of-docker@sha256:c2c2cf829505ead8e4892c88c31b6594ae94a2bbb209e16e1fac456c1a3a624e",
+      "integrity": "sha256:c2c2cf829505ead8e4892c88c31b6594ae94a2bbb209e16e1fac456c1a3a624e"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+  "name": "console",
+  "build": {
+    "dockerfile": "../Dockerfile",
+    "context": ".."
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "username": "automatic",
+      "userUid": "automatic",
+      "userGid": "automatic",
+      "installZsh": true,
+      "installOhMyZsh": false,
+      "installOhMyZshConfig": false,
+      "upgradePackages": false,
+      "configureZshAsDefaultShell": true
+    },
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
+  }
+}

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -2,9 +2,9 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [ "main", "dev" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "main", "dev" ]
+    branches: [ "main" ]
 
 jobs:
   build:
@@ -13,19 +13,19 @@ jobs:
     steps:
     - name: Check out the repo
       uses: actions/checkout@v4
-    
+
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
-    
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
-    
-    - name: Build Docker image (multi-platform)
-      uses: docker/build-push-action@v6
+
+    - name: Build devcontainer image (multi-platform, validate only)
+      uses: devcontainers/ci@v0.3
       with:
-        context: .
-        platforms: linux/amd64,linux/arm64
-        push: false
-        tags: console:test
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+        imageName: console
+        imageTag: test
+        platform: linux/amd64,linux/arm64
+        push: never
+        cacheFrom: type=gha
+        cacheTo: type=gha,mode=max

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -15,37 +15,38 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
-      
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-      
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      
-      - name: Extract metadata (tags, labels) for Docker
+
+      # devcontainers/ci has no docker/metadata-action equivalent, so derive
+      # the semver tag family (1.4.0, 1.4, 1, latest) from the release tag
+      # ourselves. Release tags are "vX.Y.Z" -- strip the "v".
+      - name: Compute image tags from release tag
         id: meta
-        uses: docker/metadata-action@v5
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          version="${RELEASE_TAG#v}"
+          minor="${version%.*}"
+          major="${minor%%.*}"
+          echo "tags=latest,${version},${minor},${major}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push devcontainer image
+        uses: devcontainers/ci@v0.3
         with:
-          images: ludorl82/console
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=raw,value=latest
-      
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          imageName: ludorl82/console
+          imageTag: ${{ steps.meta.outputs.tags }}
+          platform: linux/amd64,linux/arm64
+          push: always
+          cacheFrom: type=gha
+          cacheTo: type=gha,mode=max

--- a/.github/workflows/scheduled-rebuild.yaml
+++ b/.github/workflows/scheduled-rebuild.yaml
@@ -22,7 +22,7 @@ jobs:
       # --tag-only: creates the git tag but not a GitHub Release, so this
       # doesn't also trigger publish-image.yaml (that build is cached and
       # would just replay stale layers -- this job does its own
-      # --pull/--no-cache build below instead, which actually applies fixes)
+      # --no-cache build below instead, which actually applies fixes)
       - name: Bump patch version (tag only)
         id: bump
         env:
@@ -41,14 +41,15 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and push (force-pull base image, no cache)
-        uses: docker/build-push-action@v6
+      # No cacheFrom/cacheTo (same as before this migration): this job
+      # already runs on a clean runner with nothing to reuse, and noCache
+      # forces every RUN layer (apt-get, etc.) to actually re-execute
+      # against whatever base image gets pulled fresh for this build.
+      - name: Build and push (no cache, so package upgrades actually apply)
+        uses: devcontainers/ci@v0.3
         with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          pull: true          # force re-checking the registry for a newer ubuntu:24.04, ignore local/cached layers
-          no-cache: true      # also skip layer cache for apt-get steps, so package upgrades actually apply
-          push: true
-          tags: |
-            ludorl82/console:latest
-            ludorl82/console:${{ steps.bump.outputs.new_tag }}
+          imageName: ludorl82/console
+          imageTag: latest,${{ steps.bump.outputs.new_tag }}
+          platform: linux/amd64,linux/arm64
+          push: always
+          noCache: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@ FROM ubuntu:24.04
 ARG DEBIAN_FRONTEND=noninteractive
 ARG TZ=America/Montreal
 ARG USER=ubuntu
-ARG UID=1000
-ARG GID=1000
 
 # Base setup: packages, timezone, locale
 # apt-get upgrade here (not just install) so already-present base-image
@@ -41,29 +39,12 @@ RUN set -eux; \
     ln -sf /opt/nvim/bin/nvim /usr/local/bin/nvim; \
     rm -f /tmp/nvim.tar.gz
 
-# Docker engine (from Ubuntu repo)
-RUN set -eux; \
-    apt-get update; \
-    apt-get install -y --no-install-recommends docker.io; \
-    rm -rf /var/lib/apt/lists/*
-
-# Ensure docker group exists
-RUN set -eux; \
-    getent group docker || groupadd docker
-
-# Create or modify user and group
-# - Create group with GID if missing
-# - Create user if missing; otherwise modify existing
-# - Set shell, home, UID/GID, add to docker & sudo, set password
-RUN set -eux; \
-    if ! getent group "$USER" >/dev/null; then groupadd -g "$GID" "$USER"; fi; \
-    if getent passwd "$USER" >/dev/null; then \
-      usermod -d /home/"$USER" -s /usr/bin/zsh -u "$UID" -g "$GID" -a -G docker,sudo "$USER"; \
-    else \
-      useradd -m -d /home/"$USER" -s /usr/bin/zsh -u "$UID" -g "$GID" -G docker,sudo "$USER"; \
-    fi; \
-    mkdir -p /home/"$USER"; \
-    chown -R "$USER":"$USER" /home/"$USER"
+# Docker CLI (socket access to the host daemon) and the non-root user itself
+# are provisioned by devcontainer Features -- see .devcontainer/devcontainer.json
+# (docker-outside-of-docker + common-utils). Building this Dockerfile directly
+# with `docker build`/`docker compose build` (bypassing the devcontainer CLI)
+# skips those Features and produces a root-only image with no docker CLI;
+# use `devcontainer build` for a full image.
 
 # Retain USER at runtime (ARGs aren't available in the running container) so
 # entrypoint.sh knows which account to set the password for.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,18 @@
 ## Building the Image
 
 ### Build for Local Architecture Only
-To build the image for your current architecture (ARM64 on Raspberry Pi 5, AMD64 on x86_64):
+The Docker CLI (socket access) and the non-root user are provisioned by
+devcontainer Features declared in `.devcontainer/devcontainer.json`, not by
+the Dockerfile itself. Build with the devcontainer CLI to get a complete
+image:
+```bash
+npx @devcontainers/cli build --workspace-folder . --image-name ludorl82/console:local
+```
+
+Plain `docker compose build` still works and is faster, but skips Features
+-- useful only for quickly checking that the base Dockerfile itself (locale,
+neovim, tmux/tmuxinator, Node, sshd) still builds. The resulting image has
+no docker CLI and stays root-only:
 ```bash
 docker compose build
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,15 +3,17 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      args:
-        USER: ${USER}
     image: ludorl82/console:latest
     environment:
       - PASS=${PASS:-}
     ports:
       - "2222:22"
     volumes:
-      - "/var/run/docker.sock:/var/run/docker.sock"
+      # docker-outside-of-docker's docker-init.sh (see .devcontainer/devcontainer.json)
+      # looks for the host socket at docker-host.sock and reconciles the
+      # container's docker group GID against it before re-exposing it at
+      # the conventional /var/run/docker.sock path inside the container.
+      - "/var/run/docker.sock:/var/run/docker-host.sock"
       - "${HOME}:${HOME}"
     restart: always
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,4 +9,12 @@ if [ -n "${PASS:-}" ]; then
     echo "${CONSOLE_USER}:${PASS}" | chpasswd
 fi
 
-exec "$@"
+# docker-init.sh (installed by the docker-outside-of-docker devcontainer
+# Feature) reconciles the container's docker group GID with the mounted
+# host socket's actual GID before exec-ing into "$@" itself. Only present
+# when the image was built via the devcontainer CLI (see Dockerfile).
+if [ -x /usr/local/share/docker-init.sh ]; then
+    exec /usr/local/share/docker-init.sh "$@"
+else
+    exec "$@"
+fi


### PR DESCRIPTION
build: use devcontainer CLI and Features for the base console image

## Summary

- Replace the hand-rolled `docker.io` install and user-creation blocks in
  `Dockerfile` with devcontainer Features (`docker-outside-of-docker`,
  `common-utils`), authored via `.devcontainer/devcontainer.json`. Maintenance
  of those concerns (Docker CLI setup, non-root user creation, their own
  security patches) now lives with the upstream feature maintainers instead
  of us.
- The personalization layer (`~/.shell-scripts/console`, which adds `gh`/`aws`
  and renames the user to the real host account) is untouched by this change
  -- the base image still ships generically as `ubuntu`, exactly as before.

## Why

Two Dockerfile blocks (Docker CLI + group setup, non-root user creation) were
reinventing things that the official devcontainer Features registry already
maintains, tests, and patches. Moving them to Features means less of our own
`apt-get`/`useradd` shell code to keep correct, without changing how the image
is deployed or used day to day.

## Other changes needed to make this work

- `entrypoint.sh` now chain-execs into `docker-outside-of-docker`'s
  `docker-init.sh` when present, since that script is what reconciles the
  container's `docker` group GID against the mounted host socket. It's
  normally invoked by `devcontainer up`'s own lifecycle orchestration, which
  we don't use (we deploy via plain `docker compose`), so it has to be
  invoked explicitly from our own entrypoint instead.
- `docker-compose.yml` mounts the host socket at `/var/run/docker-host.sock`
  instead of `/var/run/docker.sock` -- that's the path `docker-init.sh`
  expects to find it at, then re-exposes it at the conventional
  `/var/run/docker.sock` path inside the container.
- All three CI workflows (`docker-image.yaml`, `publish-image.yaml`,
  `scheduled-rebuild.yaml`) now build via the `devcontainers/ci` action
  instead of `docker/build-push-action`, since Features are only applied
  through the devcontainer CLI -- a plain `docker build` would silently skip
  them.
- `README.md` documents that plain `docker compose build` now skips Features
  entirely (no Docker CLI, root-only image) -- still useful to quickly
  sanity-check that the base Dockerfile itself builds, but no longer produces
  a real, usable image on its own.

## Test plan

- [x] Built locally (arm64) via `devcontainer build`; validated:
  - image builds clean end-to-end
  - `ubuntu` user has `zsh` as its shell and is in `sudo`
  - Docker CLI works from inside as the non-root `ubuntu` user, through the
    reconciled socket
  - `nvim`, `tmux`, `tmuxinator`, `node`, `sshd` are all present
  - container boots to a running `sshd` via the real
    `entrypoint.sh` -> `docker-init.sh` -> `exec` chain
  - `chpasswd` (via the `PASS` env var) still works
- [ ] CI validates the `linux/amd64` (QEMU-emulated) build via
  `docker-image.yaml` -- not tested locally, this host is arm64 only
